### PR TITLE
Add missing <map> include (fix build with GCC 11)

### DIFF
--- a/HttpClient.h
+++ b/HttpClient.h
@@ -22,6 +22,7 @@
 #ifndef HTTPCLIENT_H
 #define HTTPCLIENT_H
 
+#include <map>
 #include <string>
 
 #include "TcpClient.h"


### PR DESCRIPTION
Needed for std::map. Fixes GCC 11 build.

BBug: https://bugs.gentoo.org/808665